### PR TITLE
chore: harden supply chain for pnpm and renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,10 +5,11 @@
     ":rebaseStalePrs"
   ],
   "schedule": ["before 3am on the first day of the month"],
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchDatasources": ["npm"],
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "eslint",
@@ -36,7 +37,21 @@
       "description": "Automerge non-major updates",
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Require manual review for framework updates (all update types)",
+      "matchPackageNames": ["react", "react-dom"],
+      "automerge": false,
+      "prPriority": 10
+    },
+    {
+      "description": "Extra labels for major framework updates",
+      "matchPackageNames": ["react", "react-dom"],
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependencies", "breaking"]
     }
   ],
   "timezone": "Europe/Berlin"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+minimum-release-age=10080
+save-exact=true


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `minimum-release-age=10080` (7-day cooldown) and `save-exact=true` so pnpm refuses freshly-published versions and pins every install.
- Align `renovate.json`: top-level `rangeStrategy` is now `pin`, the npm-wide and automerge rules use a 7-day `minimumReleaseAge`.
- Require manual review for `react` and `react-dom` on **all** update types, with `breaking` labels added on majors.

## Why
Most malicious npm releases (compromised maintainer accounts, post-install token stealers) are caught and yanked within days. Letting pnpm and Renovate share the same 7-day cooldown means no PR is opened — and no install accepted — until the community has had a chance to flag bad versions. Exact pinning + lockfile keeps installs reproducible and forces every version bump through a reviewable PR.

Adapted from aromko/raaks-little-world-website#78 for this Vite + React repo (no Next.js rules).

## Test plan
- [ ] Renovate dashboard refreshes on next schedule and opens PRs with pinned versions (no `^`/`~` ranges).
- [ ] Locally run `pnpm install` on a clean checkout and confirm no errors from the new `.npmrc` settings.
- [ ] Verify a sample Renovate PR for `react`/`react-dom` is **not** automerged.
- [ ] Confirm CI (lint, typecheck, build) still passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)